### PR TITLE
Assignment probabilities based on segment sizes

### DIFF
--- a/src/classes/batchSegmentCreator.cls
+++ b/src/classes/batchSegmentCreator.cls
@@ -33,6 +33,7 @@ gglobal class batchSegmentCreator implements Database.Batchable<SObject>,Databas
 	global List<Id> segmentCampaignIds;
 	global List<Integer> segmentSizes;
 	global List<Integer> membersAdded;
+	global List<Double> sizesCDF;
 	global String errorTxt = '';
 	global boolean keepOriginal;
 	
@@ -57,7 +58,18 @@ gglobal class batchSegmentCreator implements Database.Batchable<SObject>,Databas
 	    	Boolean assigned = false;
 	    	
 	    	while(assigned == false){
-		    	Integer assignedList = Math.floor(segmentCampaignIds.size() * Math.Random()).intValue();
+	    		Integer assignedList;
+	    		Double prob = Math.Random();
+	    		
+	    		// iterate through sizesCDF to find correct bucket
+	    		// note that sizesCDF must be sorted from smallest to largest
+	    		// probability (and should be given the generation process above)
+	    		for (Integer i=0; i<sizesCDF.size(); i++) {
+	    			if (sizesCDF[i] >= prob) {
+	    				assignedList = i;
+	    				break;
+	    			}
+	    		}
 
 				if((membersAdded[assignedList] < segmentSizes[assignedList])){		    
 					 newCampaignMembers.add(

--- a/src/classes/memberAssignment.cls
+++ b/src/classes/memberAssignment.cls
@@ -34,6 +34,9 @@ public with sharing class memberAssignment {
 	static List<Integer> members;
 	static List<CampaignMember> newCampaignMembers;	
 	static Boolean keep;
+	static Integer totalSize;
+	static List<Double> sizesPDF;
+	static List<Double> sizesCDF;
 	
 	public static boolean assignMembersNow(Id parentCampaignId, List<Id> segmentCampaignIds, List<Integer> segmentSizes, List<Integer> membersAdded, Boolean keepOriginal){
 		campId = parentCampaignId;
@@ -44,6 +47,29 @@ public with sharing class memberAssignment {
 		newCampaignMembers = new List<CampaignMember>();
 		
 		List<CampaignMember> oldMembers = [select id,campaignId, leadId, contactid from campaignMember where CampaignId = :campId];
+
+		// Figure out the fraction that should go into each list,
+		// then generate a cumulative distribution function to
+		// use in making the assignments
+		totalSize = 0;
+		for (Ingeger i : sizes) {
+			totalSize += i;
+		}
+
+		sizesPDF = new List<Double>();
+		for (Integer s : sizes) {
+			sizesPDF.add(1.0*s/totalSize);
+		}
+
+		// roll up the PDF into a CDF
+		sizesCDF = new List<Double>();
+		sizesCDF.add(sizesPDF[0]);
+		for (i=1; i<sizesPDF.size(); i++) {
+			sizesCDF.add(sizesPDF[i] + sizesCDF[i-1])
+		}
+		// be sure final value is 1.0, regardless of rounding issues:
+		sizesCDF[sizesCDF.size()-1] = 1.0
+
 		
 		for(CampaignMember thisMember : oldMembers){
 		 	assignMember(thisMember);		    
@@ -66,9 +92,20 @@ public with sharing class memberAssignment {
 	}
 			
 	private static void assignMember(CampaignMember thisCampaignMember){
-		Integer assignedList = Math.floor(semgmentIds.size() * Math.Random()).intValue();
-		
-		if((members[assignedList] < sizes[assignedList])){		    
+		Integer assignedList;
+		Double prob = Math.Random();
+
+		// iterate through sizesCDF to find first correct bucket
+		// note that sizesCDF must be sorted from smallest to largest
+		// probability (and should be given the generation process above)
+		for (i=0; i<sizesCDF.size(); i++) {
+			if (sizesCDF[i] >= prob) {
+				assignedList = i;
+				break;
+			}
+		}
+
+		if(members[assignedList] < sizes[assignedList]){		    
 			 newCampaignMembers.add(
 			 	new CampaignMember(
 					CampaignId = semgmentIds[assignedList],
@@ -76,9 +113,7 @@ public with sharing class memberAssignment {
 					ContactId = thisCampaignMember.ContactId		
 			 	)
 			 );
-			 if(members[assignedList] < sizes[assignedList]){
-			 	members[assignedList]++;
-			 }
+			 members[assignedList]++;
 		} else {
 			assignMember(thisCampaignMember);
 		}

--- a/src/classes/memberAssignment.cls
+++ b/src/classes/memberAssignment.cls
@@ -68,7 +68,9 @@ public with sharing class memberAssignment {
 		for(CampaignMember thisMember : oldMembers){
 		 	assignMember(thisMember);		    
 		}
-		system.debug('******newCampaignMembers = '+newCampaignMembers);
+		// This may be millions of records long in prod, probably not
+		// worth spitting out to the console every time.
+		// system.debug('******newCampaignMembers = '+newCampaignMembers);
 		if(!newCampaignMembers.isEmpty()){
 			try {
 				insert newCampaignMembers;

--- a/src/classes/memberAssignment.cls
+++ b/src/classes/memberAssignment.cls
@@ -35,7 +35,6 @@ public with sharing class memberAssignment {
 	static List<CampaignMember> newCampaignMembers;	
 	static Boolean keep;
 	static Integer totalSize;
-	static List<Double> sizesPDF;
 	static List<Double> sizesCDF;
 	
 	public static boolean assignMembersNow(Id parentCampaignId, List<Id> segmentCampaignIds, List<Integer> segmentSizes, List<Integer> membersAdded, Boolean keepOriginal){
@@ -52,20 +51,15 @@ public with sharing class memberAssignment {
 		// then generate a cumulative distribution function to
 		// use in making the assignments
 		totalSize = 0;
-		for (Ingeger i : sizes) {
-			totalSize += i;
+		for (Ingeger s : sizes) {
+			totalSize += s;
 		}
 
-		sizesPDF = new List<Double>();
-		for (Integer s : sizes) {
-			sizesPDF.add(1.0*s/totalSize);
-		}
-
-		// roll up the PDF into a CDF
+		// Generate the CDF
 		sizesCDF = new List<Double>();
-		sizesCDF.add(sizesPDF[0]);
-		for (i=1; i<sizesPDF.size(); i++) {
-			sizesCDF.add(sizesPDF[i] + sizesCDF[i-1]);
+		sizesCDF.add(1.0*sizes[0]/totalSize);
+		for (Integer i=1; i<sizes.size() : i++) {
+			sizesCDF.add(sizesCDF[i-1] + (1.0*sizes[i]/totalSize));
 		}
 		// be sure final value is 1.0, regardless of rounding issues:
 		sizesCDF[sizesCDF.size()-1] = 1.0;
@@ -98,7 +92,7 @@ public with sharing class memberAssignment {
 		// iterate through sizesCDF to find first correct bucket
 		// note that sizesCDF must be sorted from smallest to largest
 		// probability (and should be given the generation process above)
-		for (i=0; i<sizesCDF.size(); i++) {
+		for (Integer i=0; i<sizesCDF.size(); i++) {
 			if (sizesCDF[i] >= prob) {
 				assignedList = i;
 				break;

--- a/src/classes/memberAssignment.cls
+++ b/src/classes/memberAssignment.cls
@@ -51,14 +51,14 @@ public with sharing class memberAssignment {
 		// then generate a cumulative distribution function to
 		// use in making the assignments
 		totalSize = 0;
-		for (Ingeger s : sizes) {
+		for (Integer s : sizes) {
 			totalSize += s;
 		}
 
 		// Generate the CDF
 		sizesCDF = new List<Double>();
 		sizesCDF.add(1.0*sizes[0]/totalSize);
-		for (Integer i=1; i<sizes.size() : i++) {
+		for (Integer i=1; i<sizes.size(); i++) {
 			sizesCDF.add(sizesCDF[i-1] + (1.0*sizes[i]/totalSize));
 		}
 		// be sure final value is 1.0, regardless of rounding issues:

--- a/src/classes/memberAssignment.cls
+++ b/src/classes/memberAssignment.cls
@@ -65,10 +65,10 @@ public with sharing class memberAssignment {
 		sizesCDF = new List<Double>();
 		sizesCDF.add(sizesPDF[0]);
 		for (i=1; i<sizesPDF.size(); i++) {
-			sizesCDF.add(sizesPDF[i] + sizesCDF[i-1])
+			sizesCDF.add(sizesPDF[i] + sizesCDF[i-1]);
 		}
 		// be sure final value is 1.0, regardless of rounding issues:
-		sizesCDF[sizesCDF.size()-1] = 1.0
+		sizesCDF[sizesCDF.size()-1] = 1.0;
 
 		
 		for(CampaignMember thisMember : oldMembers){

--- a/src/classes/segmentsController.cls
+++ b/src/classes/segmentsController.cls
@@ -208,6 +208,26 @@ public with sharing class segmentsController {
                     batchSegments.segmentCampaignIds = newCampaignIds;
                     batchSegments.segmentSizes = segmentSizes;
                     batchSegments.membersAdded = membersAdded;
+
+		    // Figure out the fraction that should go into each list,
+		    // then generate a cumulative distribution function to
+		    // use in making the assignments
+		    Integer totalSize = 0;
+		    for (Integer s : segmentSizes) {
+		    	totalSize += s;
+		    }
+		    
+		    // Generate the CDF
+		    List<Double> segmentSizesCDF = new List<Double>();
+		    segmentSizesCDF.add(1.0*segmentSizes[0]/totalSize);
+		    for (Integer i=1; i<segmentSizes.size(); i++) {
+		    	segmentSizesCDF.add(segmentSizesCDF[i-1] + (1.0*segmentSizes[i]/totalSize));
+		    }
+		    // be sure final value is 1.0, regardless of rounding issues:
+		    segmentSizesCDF[segmentSizesCDF.size()-1] = 1.0;
+		    
+		    batchSegments.sizesCDF = segmentSizesCDF;
+		    
                     batchSegments.keepOriginal = keepOriginal;
                     batchSegments.email = batchEmailNotification;
                     ID batchprocessid = Database.executeBatch(batchSegments);


### PR DESCRIPTION
We've been using this tool to create segments for email campaigns, but have run into an issue when using it to generate segments of much different sizes. 

The current code is looping over parent campaign members in the order they come out of the underlying datastore and attempting to assign to each of the groups with equal probability. In practice, this means small groups fill up first (presumably with older contacts who have lower primary keys) and larger groups end up over-representing contacts who are assigned later (presumably newer contacts with larger primary keys). Additionally, this has a performance impact by continuing to attempt to assign members to the small segments even after they've filled up, resulting in many recursive calls to `assignMember()`.

This patch assigns a probability to each segment based on its relative size and then makes assignments based on those probabilities. As a result, members are added to smaller segments at a slower rate than to the larger segments, providing a more even distribution of assignments relative to the initial ordering of the contacts and fewer recursive calls.
